### PR TITLE
Issue 51

### DIFF
--- a/gradle/gradle/packaging.plugin-vimdriver-openstack.debian.gradle
+++ b/gradle/gradle/packaging.plugin-vimdriver-openstack.debian.gradle
@@ -29,11 +29,11 @@ ext {
 task logDebianPackageJavaDependency() {
     // print the logs about the correct java dependency
     doLast() {
-        if (project.hasProperty('javaVersion') && (javaVersion == "8")) {
-            println " * Adding debian package dependency to Java 8"
+        if (project.hasProperty('javaVersion') && (javaVersion == "7")) {
+            println " * Adding debian package dependency to Java 7"
         }
         else {
-            println " * Adding debian package dependency to Java 7"
+            println " * Adding debian package dependency to Java 8"
         }
     }
 }
@@ -54,11 +54,11 @@ task makeDeb(type: Deb, dependsOn: [jar, build, logDebianPackageJavaDependency])
     preInstall file('gradle/gradle/scripts/debian/preinst')
 
     // set the correct java dependency
-    if (project.hasProperty('javaVersion') && (javaVersion == "8")) {
-        requires('openjdk-8-jre')
+    if (project.hasProperty('javaVersion') && (javaVersion == "7")) {
+        requires('openjdk-7-jre')
     }
     else {
-        requires('openjdk-7-jre')
+        requires('openjdk-8-jre')
     }
 
     // Copy files from "from path" to "into path"

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -452,7 +452,10 @@ public class OpenStack4JDriver extends VimDriver {
             + " is connected to");
 
     for (org.openstack4j.model.network.Network network : networks) {
-      if (network.getName().equals(internalNetworkName) && network.getTenantId().equals(tenantId)) {
+      if (network.getName().equals(internalNetworkName)
+          && (network.getTenantId().equals(tenantId)
+              || network.isShared()
+              || network.isRouterExternal())) {
         internalNetworkId = network.getId();
         break;
       }

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -428,9 +428,6 @@ public class OpenStack4JDriver extends VimDriver {
     throw new VimDriverException("Flavor with name " + flavor + " was not found");
   }
 
-
-
-
   private String getImageIdFromName(BaseVimInstance vimInstance, String imageName)
       throws VimDriverException {
     log.debug("Retrieving id of the image named " + imageName + " on PoP " + vimInstance.getName());
@@ -782,7 +779,7 @@ public class OpenStack4JDriver extends VimDriver {
   }
 
   public Server rebuildServer(BaseVimInstance vimInstance, String serverId, String imageId)
-          throws VimDriverException {
+      throws VimDriverException {
     OpenstackVimInstance openstackVimInstance = (OpenstackVimInstance) vimInstance;
     OSClient os = this.authenticate(openstackVimInstance);
     RebuildOptions rebuildOptions = RebuildOptions.create();

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -18,6 +18,31 @@ package org.openbaton.drivers.openstack4j;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.net.util.SubnetUtils;
 import org.openbaton.catalogue.keys.PopKeypair;
@@ -65,32 +90,6 @@ import org.openstack4j.model.network.RouterInterface;
 import org.openstack4j.openstack.OSFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class OpenStack4JDriver extends VimDriver {
 
@@ -896,7 +895,7 @@ public class OpenStack4JDriver extends VimDriver {
           server
               .getFloatingIps()
               .put(
-                  vnfdConnectionPoint.getFloatingIp(),
+                  vnfdConnectionPoint.getVirtual_link_reference(),
                   this.translateToNAT(
                       associateFloatingIpToNetwork(os, tenantId, server4j, vnfdConnectionPoint)));
         } finally {

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -309,7 +309,8 @@ public class OpenStack4JDriver extends VimDriver {
           if (networkByName.isPresent()) {
             subnets = networkByName.get().getSubnets();
           } else {
-            org.openstack4j.model.network.Network network = os.networking().network().get(openstackNetId);
+            org.openstack4j.model.network.Network network =
+                os.networking().network().get(openstackNetId);
             subnets = network.getSubnets();
           }
 
@@ -355,7 +356,8 @@ public class OpenStack4JDriver extends VimDriver {
         }
         Port port = os.networking().port().create(portBuilder.build());
         if (null == port) {
-          throw new VimDriverException("Unable to create port on network with id " + openstackNetId);
+          throw new VimDriverException(
+              "Unable to create port on network with id " + openstackNetId);
         }
         log.debug("created port with id " + port.getId());
 
@@ -1323,7 +1325,11 @@ public class OpenStack4JDriver extends VimDriver {
   }
 
   private NetFloatingIP findFloatingIpAddress(
-      OSClient os, String fipValue, String tenantId, String internalNetworkName, OpenstackVimInstance vimInstance)
+      OSClient os,
+      String fipValue,
+      String tenantId,
+      String internalNetworkName,
+      OpenstackVimInstance vimInstance)
       throws VimDriverException {
     if (fipValue.trim().equalsIgnoreCase("random") || fipValue.trim().equals("")) {
       return listFloatingIps(os, tenantId, internalNetworkName, vimInstance).get(0);
@@ -1412,7 +1418,7 @@ public class OpenStack4JDriver extends VimDriver {
                                             ip.getAddr(),
                                             getTenantId(openstackVimInstance, os),
                                             "",
-                                        openstackVimInstance)
+                                            openstackVimInstance)
                                         .getId());
                           } catch (VimDriverException e) {
                             e.printStackTrace();

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -1668,4 +1668,3 @@ public class OpenStack4JDriver extends VimDriver {
     return "openstack";
   }
 }
-

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -119,13 +119,6 @@ public class OpenStack4JDriver extends VimDriver {
                 : Identifier.byName(vimInstance.getDomain());
         Identifier project = Identifier.byId(vimInstance.getTenant());
 
-        //        String[] domainProjectSplit = vimInstance.getTenant().split(Pattern.quote(":"));
-        //        if (domainProjectSplit.length == 2) {
-        //          log.trace("Found domain name and project id: " + Arrays.toString(domainProjectSplit));
-        //          domain = Identifier.byName(domainProjectSplit[0]);
-        //          project = Identifier.byId(domainProjectSplit[1]);
-        //        }
-
         log.trace(
             "Authenticate method with domain id: "
                 + domain.getId()

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -79,6 +79,7 @@ import org.openstack4j.model.network.NetQuota;
 import org.openstack4j.model.network.Port;
 import org.openstack4j.model.network.Router;
 import org.openstack4j.model.network.RouterInterface;
+import org.openstack4j.model.network.builder.SubnetBuilder;
 import org.openstack4j.model.network.options.PortListOptions;
 import org.openstack4j.openstack.OSFactory;
 import org.slf4j.Logger;
@@ -1479,19 +1480,30 @@ public class OpenStack4JDriver extends VimDriver {
   public Subnet createSubnet(BaseVimInstance vimInstance, BaseNetwork createdNetwork, Subnet subnet)
       throws VimDriverException {
     OSClient os = this.authenticate((OpenstackVimInstance) vimInstance);
+    SubnetBuilder subnetBuilder =
+        Builders.subnet()
+            .name(subnet.getName())
+            .networkId(createdNetwork.getExtId())
+            .ipVersion(IPVersionType.V4)
+            .cidr(subnet.getCidr())
+            .enableDHCP(true)
+            .gateway(subnet.getGatewayIp());
+
+    if (subnet.getDns() != null && !subnet.getDns().isEmpty())
+      subnet
+          .getDns()
+          .forEach(
+              dns -> {
+                log.info(String.format("Adding DNS: %s", dns));
+                subnetBuilder.addDNSNameServer(dns);
+              });
+    else {
+      String dns = properties.getProperty("openstack4j.dns.ip", "8.8.8.8");
+      log.info(String.format("Adding DNS: %s", dns));
+      subnetBuilder.addDNSNameServer(dns);
+    }
     org.openstack4j.model.network.Subnet subnet4j =
-        os.networking()
-            .subnet()
-            .create(
-                Builders.subnet()
-                    .name(subnet.getName())
-                    .networkId(createdNetwork.getExtId())
-                    .ipVersion(IPVersionType.V4)
-                    .cidr(subnet.getCidr())
-                    .addDNSNameServer(properties.getProperty("openstack4j.dns.ip", "8.8.8.8"))
-                    .enableDHCP(true)
-                    .gateway(subnet.getGatewayIp())
-                    .build());
+        os.networking().subnet().create(subnetBuilder.build());
 
     Subnet sn = Utils.getSubnet(subnet4j);
     try {
@@ -1556,40 +1568,42 @@ public class OpenStack4JDriver extends VimDriver {
                 } catch (InterruptedException e) {
                   e.printStackTrace();
                 }
-                try {
-                  network
-                      .getSubnets()
-                      .forEach(
-                          subnetId -> {
-                            for (Router r : os.networking().router().list()) {
-                              os.networking()
-                                  .port()
-                                  .list()
-                                  .stream()
-                                  .filter(
-                                      p ->
-                                          p.getDeviceOwner().equals("network:router_interface")
-                                              && p.getDeviceId().equals(r.getId())
-                                              && p.getFixedIps()
-                                                  .stream()
-                                                  .anyMatch(
-                                                      ip -> ip.getSubnetId().equals(subnetId)))
-                                  .forEach(
-                                      p -> {
-                                        log.debug(
-                                            String.format(
-                                                "Detaching subnet %s from router %s identified by port %s",
-                                                subnetId, r.getId(), p.getId()));
-                                        os.networking()
-                                            .router()
-                                            .detachInterface(r.getId(), subnetId, p.getId());
-                                      });
-                            }
-                          });
-                } catch (Throwable e) {
-                  attempts++;
-                  success = false;
-                  continue;
+                if (!network.getSubnets().isEmpty()) {
+                  try {
+                    network
+                        .getSubnets()
+                        .forEach(
+                            subnetId -> {
+                              for (Router r : os.networking().router().list()) {
+                                os.networking()
+                                    .port()
+                                    .list()
+                                    .stream()
+                                    .filter(
+                                        p ->
+                                            p.getDeviceOwner().equals("network:router_interface")
+                                                && p.getDeviceId().equals(r.getId())
+                                                && p.getFixedIps()
+                                                    .stream()
+                                                    .anyMatch(
+                                                        ip -> ip.getSubnetId().equals(subnetId)))
+                                    .forEach(
+                                        p -> {
+                                          log.debug(
+                                              String.format(
+                                                  "Detaching subnet %s from router %s identified by port %s",
+                                                  subnetId, r.getId(), p.getId()));
+                                          os.networking()
+                                              .router()
+                                              .detachInterface(r.getId(), subnetId, p.getId());
+                                        });
+                              }
+                            });
+                  } catch (Throwable e) {
+                    attempts++;
+                    success = false;
+                    continue;
+                  }
                 }
 
                 success = osClient.networking().network().delete(extId).isSuccess();
@@ -1598,7 +1612,7 @@ public class OpenStack4JDriver extends VimDriver {
               if (!success) {
                 log.error(String.format("Not able to delete network with id %s", extId));
               } else {
-                log.info(String.format("Removed network %s", extId));
+                log.info(String.format("Deleted network %s", extId));
               }
             })
         .start();

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -74,6 +74,7 @@ import org.openstack4j.model.compute.Address;
 import org.openstack4j.model.compute.Flavor;
 import org.openstack4j.model.compute.QuotaSet;
 import org.openstack4j.model.compute.ServerCreate;
+import org.openstack4j.model.compute.actions.RebuildOptions;
 import org.openstack4j.model.compute.builder.ServerCreateBuilder;
 import org.openstack4j.model.compute.ext.AvailabilityZone;
 import org.openstack4j.model.identity.v2.Tenant;
@@ -480,6 +481,23 @@ public class OpenStack4JDriver extends VimDriver {
 
     return router.getExternalGatewayInfo().getNetworkId();
   }
+
+  public Server rebuildServer(BaseVimInstance vimInstance, String serverId, String imageName) throws VimDriverException {
+    OpenstackVimInstance openstackVimInstance = (OpenstackVimInstance) vimInstance;
+    OSClient os = this.authenticate(openstackVimInstance);
+    RebuildOptions rebuildOptions = RebuildOptions.create();
+    if(imageName!=null) {
+      rebuildOptions.image(imageName);
+      log.info("Rebuilding server: "+ serverId +" with image: "+imageName);
+    }else log.info("Rebuilding server: "+ serverId);
+    ActionResponse response = os.compute().servers().rebuild(serverId,rebuildOptions);
+
+    if (!response.isSuccess()) {
+      throw new VimDriverException("Error uploading image: " + response.getFault());
+    }
+    return Utils.getServer(os.compute().servers().get(serverId));
+  }
+
 
   private List<NetFloatingIP> listFloatingIps(OSClient os, String tenantId, String networkName) {
     List<NetFloatingIP> res = new ArrayList<>();

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -440,7 +440,8 @@ public class OpenStack4JDriver extends VimDriver {
     throw new VimDriverException("Not found image '" + imageName + "' on " + vimInstance.getName());
   }
 
-  private String getExternalNetworkId(OSClient os, String internalNetworkName) throws Exception {
+  private String getExternalNetworkId(OSClient os, String tenantId, String internalNetworkName)
+      throws Exception {
     String internalNetworkId = "";
     List<? extends org.openstack4j.model.network.Network> networks =
         os.networking().network().list();
@@ -451,8 +452,7 @@ public class OpenStack4JDriver extends VimDriver {
             + " is connected to");
 
     for (org.openstack4j.model.network.Network network : networks) {
-      //log.debug(" network "  + network);
-      if (network.getName().equals(internalNetworkName)) {
+      if (network.getName().equals(internalNetworkName) && network.getTenantId().equals(tenantId)) {
         internalNetworkId = network.getId();
         break;
       }
@@ -1132,7 +1132,8 @@ public class OpenStack4JDriver extends VimDriver {
                 .orElseThrow(() -> new VimDriverException("Network not found"))
                 .getExtId());
       } else {
-        extNetworkId = getExternalNetworkId(os, vnfdConnectionPoint.getVirtual_link_reference());
+        extNetworkId =
+            getExternalNetworkId(os, tenantId, vnfdConnectionPoint.getVirtual_link_reference());
         log.debug(
             "Retrieved external network: "
                 + new GsonBuilder()

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -482,22 +482,22 @@ public class OpenStack4JDriver extends VimDriver {
     return router.getExternalGatewayInfo().getNetworkId();
   }
 
-  public Server rebuildServer(BaseVimInstance vimInstance, String serverId, String imageName) throws VimDriverException {
+  public Server rebuildServer(BaseVimInstance vimInstance, String serverId, String imageId)
+      throws VimDriverException {
     OpenstackVimInstance openstackVimInstance = (OpenstackVimInstance) vimInstance;
     OSClient os = this.authenticate(openstackVimInstance);
     RebuildOptions rebuildOptions = RebuildOptions.create();
-    if(imageName!=null) {
-      rebuildOptions.image(imageName);
-      log.info("Rebuilding server: "+ serverId +" with image: "+imageName);
-    }else log.info("Rebuilding server: "+ serverId);
-    ActionResponse response = os.compute().servers().rebuild(serverId,rebuildOptions);
-
+    if (imageId != null) {
+      rebuildOptions.image(imageId);
+      log.info("Rebuilding server: " + serverId + " with image: " + imageId);
+    } else log.info("Rebuilding server: " + serverId);
+    ActionResponse response = os.compute().servers().rebuild(serverId, rebuildOptions);
     if (!response.isSuccess()) {
-      throw new VimDriverException("Error uploading image: " + response.getFault());
+      log.error("Error rebuilding image: " + response.getFault());
+      throw new VimDriverException("Error rebuilding image: " + response.getFault());
     }
     return Utils.getServer(os.compute().servers().get(serverId));
   }
-
 
   private List<NetFloatingIP> listFloatingIps(OSClient os, String tenantId, String networkName) {
     List<NetFloatingIP> res = new ArrayList<>();

--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -457,6 +457,7 @@ public class OpenStack4JDriver extends VimDriver {
               || network.isShared()
               || network.isRouterExternal())) {
         internalNetworkId = network.getId();
+        log.debug(String.format("Found network [%s] : %s", network.getId(), network.getName()));
         break;
       }
     }
@@ -1062,7 +1063,7 @@ public class OpenStack4JDriver extends VimDriver {
     for (Map.Entry<Object, Object> entry : natRules.entrySet()) {
       String fromCidr = (String) entry.getKey();
       String toCidr = (String) entry.getValue();
-      log.debug("Source CIDR is: " + fromCidr);
+      log.trace("Source CIDR is: " + fromCidr);
       SubnetUtils utilsFrom = new SubnetUtils(fromCidr);
       SubnetUtils utilsTo = new SubnetUtils(toCidr);
 


### PR DESCRIPTION
When there are multiple connections to the same network code will currently attempt to assign a floating ip to all of the fixed ip's on that network. Instead of assigning networks to a server pre-create the ports and then assign the ports to the server. This also allows for assigning the correct floating ip to the correct fixed ip.