### PR TITLE
Issue 280

### DIFF
--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -339,7 +339,9 @@ public class OpenStack4JDriver extends VimDriver {
 
         } else {
           portBuilder =
-              Builders.port().name(Utils.buildPortName(vnfdConnectionPoint)).networkId(openstackNetId);
+              Builders.port()
+                  .name(Utils.buildPortName(vnfdConnectionPoint))
+                  .networkId(openstackNetId);
         }
 
         List<? extends SecGroupExtension> osSecGroups = os.compute().securityGroups().list();
@@ -415,14 +417,16 @@ public class OpenStack4JDriver extends VimDriver {
         server4j = os.compute().servers().boot(sc);
       }
 
-      Map<String, String> portNamesAndInterfaceIds = Utils.getPortNamesAndInterfaceIds(vnfdConnectionPoints);
+      Map<String, String> portNamesAndInterfaceIds =
+          Utils.getPortNamesAndInterfaceIds(vnfdConnectionPoints);
       server = Utils.getServer(server4j, os, portNamesAndInterfaceIds);
     } catch (Exception e) {
       log.error(e.getMessage(), e);
 
       // if any ports have been created delete them
       for (VNFDConnectionPoint vnfdConnectionPoint : vnfdcps) {
-        PortListOptions options = PortListOptions.create().name(Utils.buildPortName(vnfdConnectionPoint));
+        PortListOptions options =
+            PortListOptions.create().name(Utils.buildPortName(vnfdConnectionPoint));
         List<? extends Port> ports = os.networking().port().list(options);
         log.debug(
             "List of ports is " + new GsonBuilder().setPrettyPrinting().create().toJson(ports));
@@ -1271,7 +1275,8 @@ public class OpenStack4JDriver extends VimDriver {
       os.compute().floatingIps().allocateIP(poolName);
     }
 
-    PortListOptions options = PortListOptions.create().name(Utils.buildPortName(vnfdConnectionPoint));
+    PortListOptions options =
+        PortListOptions.create().name(Utils.buildPortName(vnfdConnectionPoint));
     List<? extends Port> ports = os.networking().port().list(options);
     log.debug("List of ports is " + new GsonBuilder().setPrettyPrinting().create().toJson(ports));
 

--- a/src/main/java/org/openbaton/drivers/openstack4j/Utils.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/Utils.java
@@ -35,7 +35,9 @@ class Utils {
     return portNamePrefix + vnfdConnectionPoint.getId();
   }
 
-  static String getPortNamePrefix() { return portNamePrefix; }
+  static String getPortNamePrefix() {
+    return portNamePrefix;
+  }
 
   static DeploymentFlavour getFlavor(Flavor flavor4j) {
     DeploymentFlavour deploymentFlavour = new DeploymentFlavour();
@@ -47,7 +49,8 @@ class Utils {
     return deploymentFlavour;
   }
 
-  static org.openbaton.catalogue.nfvo.Server getServer(Server server4j, OSClient os, Map<String, String> portNamesAndInterfaceIds) {
+  static org.openbaton.catalogue.nfvo.Server getServer(
+      Server server4j, OSClient os, Map<String, String> portNamesAndInterfaceIds) {
     log.trace("Server: " + new GsonBuilder().setPrettyPrinting().create().toJson(server4j));
     org.openbaton.catalogue.nfvo.Server server = new org.openbaton.catalogue.nfvo.Server();
     server.setName(server4j.getName());
@@ -86,7 +89,7 @@ class Utils {
         os.networking().subnet().get(ip4j.getSubnetId()).getName();
         subnetIp.setSubnetName(os.networking().subnet().get(ip4j.getSubnetId()).getName());
 
-        if(portNamesAndInterfaceIds.containsKey(port.getName())) {
+        if (portNamesAndInterfaceIds.containsKey(port.getName())) {
           subnetIp.setInterfaceId(portNamesAndInterfaceIds.get(port.getName()));
         }
 
@@ -108,7 +111,8 @@ class Utils {
   static Map<String, String> getPortNamesAndInterfaceIds(Set<VNFDConnectionPoint> vnfdcps) {
     Map<String, String> interfaces = new HashMap<String, String>();
     for (VNFDConnectionPoint vnfdConnectionPoint : vnfdcps) {
-      interfaces.put(buildPortName(vnfdConnectionPoint), vnfdConnectionPoint.getInterfaceId().toString());
+      interfaces.put(
+          buildPortName(vnfdConnectionPoint), vnfdConnectionPoint.getInterfaceId().toString());
     }
     return interfaces;
   }


### PR DESCRIPTION
Currently if there is more than one interface (openstack port) on a single network only the first interfaces's IP address is available to the scripts as $network_name. If there is more than one subnet associated with a particular network (i.e. IPv4 and IPv6) openstack assigns IP addresses from both but the value of $network_name in the scripts is randomly assigned between the two.

Update the VNFCInstance to have not only a single ip address per network but now have all ip addresses including their subnets and interface id's if specified in the vnfd.json file.

This references issue openbaton/NFVO#280 and should be pulled with openbaton/NFVO#281