### PR TITLE
Fix: Assignment of fixed IP addresses to VMs

### DIFF
--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -329,7 +329,6 @@ public class OpenStack4JDriver extends VimDriver {
         PortBuilder portBuilder = null;
         if (vnfdConnectionPoint.getFixedIp() != null
             && !vnfdConnectionPoint.getFixedIp().equals("")) {
-          sc.addNetwork(openstackNetId, vnfdConnectionPoint.getFixedIp());
 
           // get the subnet associated with the network
           List<String> subnets;


### PR DESCRIPTION
This functionality was broken in a previous commit. As a result two networks specifying the same thing were added to the ServerCreate object which is used to create the VM. Therefore the VIM driver threw an exception saying that the IP was already in use.