### PR TITLE
Check to see if the fixedIp of the floating ip is null before comparing it to empty string

### DIFF
--- a/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
+++ b/src/main/java/org/openbaton/drivers/openstack4j/OpenStack4JDriver.java
@@ -1345,7 +1345,7 @@ public class OpenStack4JDriver extends VimDriver {
     List<? extends NetFloatingIP> netFloatingIPS = os.networking().floatingip().list();
     for (NetFloatingIP fip : netFloatingIPS) {
       if (fip.getFloatingIpAddress().equals(fipValue)
-          && fip.getFixedIpAddress().equals("")
+          && (null == fip.getFixedIpAddress() || fip.getFixedIpAddress().equals(""))
           && fip.getTenantId().equals(tenantId)) {
         return fip;
       }


### PR DESCRIPTION
If that field is null it is causing an exception to be thrown and not return the desired data.

This addresses Issue #67 